### PR TITLE
vertical align icon

### DIFF
--- a/st_flexible_callout_elements/flexible_callout.py
+++ b/st_flexible_callout_elements/flexible_callout.py
@@ -59,7 +59,7 @@ def flexible_callout(
         if icon.startswith(":material/") and icon.endswith(":"):
             icon_name = icon[10:-1]
             font_link = '<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />'
-            icon_content = f'<span class="material-symbols-rounded" style="font-size: {icon_size}px; color: {font_color};">{icon_name}</span>'
+            icon_content = f'<span class="material-symbols-rounded" style="font-size: {icon_size}px; color: {font_color}; vertical-align: middle;">{icon_name}</span>'
         else:
             # Handle emoji or other text icons
             icon_content = f'<span style="font-size: {icon_size}px;">{icon}</span>'


### PR DESCRIPTION
Thanks for adding the icon feature! One small thing: I noted the icon was slightly vertically uncentered. This small addition makes sure it is nicely aligned. 

Before:
<img width="732" alt="Screenshot 2025-06-23 at 18 22 09" src="https://github.com/user-attachments/assets/0b676ed8-bfeb-48fd-8af9-fca2a3421ea2" />

After:
<img width="727" alt="Screenshot 2025-06-23 at 18 22 17" src="https://github.com/user-attachments/assets/e08bed0b-e4c5-4e6d-8c9d-8c8b4d8a1998" />

If you agree with the PR, could you push this to PyPI? Thanks!

 